### PR TITLE
Update reset.scss - Add border-box for :before and :after

### DIFF
--- a/sass/_resets.scss
+++ b/sass/_resets.scss
@@ -3,7 +3,9 @@
 /*-------------------------*/
 
 // No more annoying padding + width calculations...
-* {
+*,
+*:after,
+*:before {
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
Hello, Great project! I just stepped into this issue, so I'm opening this minor PR. In this version of reset it's missing the `box-sizing: border-box` property for `:after` and `:before` pseudo elements. Cheers!
